### PR TITLE
Add google command to ExternalCommands

### DIFF
--- a/ExternalCommands/Commands/google.js
+++ b/ExternalCommands/Commands/google.js
@@ -1,0 +1,64 @@
+const google = require('google');
+const log = (str) => window.DI.Helpers.sendLog('Google', str, 'https://upload.wikimedia.org/wikipedia/commons/2/2d/Google-favicon-2015.png');
+module.exports = {
+    info: 'Searches for things on Google.',
+    usage: '<query> [results: <number>] [--send]',
+    func: (args) => {
+        if (!args[0]) {
+            return log(`You need to specify arguments:\n\`\`\`<query> [results: <number>] [--send]\`\`\``);
+        }
+
+        const sendToChannel = args.includes('--send');
+        args = args.join(' ').replace('--send', '');
+        const resultsRX = /results: *([0-9]*)/g;
+        let results = resultsRX.exec(args);
+        if (results) {
+            results = parseInt(results[1]);
+            if (results < 1) {
+                return log('You can\'t request less than one result.');
+            }
+            args = args.replace(`results: ${results}`, '');
+        } else {
+            results = 3; // default amount of results to display if the results parameter isn't supplied
+        }
+
+        google(args, (err, res) => {
+            if (err) {
+                return log(`Something went wrong while searching.\n\`\`\`${err.stack}\`\`\``);
+            }
+
+            res = res.links.filter(link => link.href && link.description);
+            if (!res[0]) {
+                return log('No results found. Please try a different search term.');
+            }
+
+            if (results > res.length) {
+                results = res.length;
+            }
+
+            const embeds = [];
+            for (let i = 0; i < results; i++) {
+                embeds[i] = {
+                    title: `Search results for ${args}`,
+                    url: res[i].href,
+                    description: res[i].description
+                };
+            }
+
+            if (sendToChannel) {
+                if (!window.DI.client.selectedChannel) {
+                    return;
+                }
+                const embedPerms = window.DI.client.selectedChannel.type !== 'text' || window.DI.client.selectedChannel.permissionsFor(window.DI.client.user).has('EMBED_LINKS');
+
+                if (embedPerms) {
+                    window.DI.client.selectedChannel.send({ embed: embeds[0] });
+                } else {
+                    window.DI.client.selectedChannel.send(embeds[0].description);
+                }
+            } else {
+                log({ embeds });
+            }
+        });
+    }
+};

--- a/ExternalCommands/Commands/google.js
+++ b/ExternalCommands/Commands/google.js
@@ -31,15 +31,15 @@ module.exports = {
             if (!res[0]) {
                 return log('No results found. Please try a different search term.');
             }
-
             if (results > res.length) {
                 results = res.length;
             }
 
+            const content = `Search results for \`${args}\`:`;
             const embeds = [];
             for (let i = 0; i < results; i++) {
                 embeds[i] = {
-                    title: `Search results for ${args}`,
+                    title: res[i].title,
                     url: res[i].href,
                     description: res[i].description
                 };
@@ -52,12 +52,12 @@ module.exports = {
                 const embedPerms = window.DI.client.selectedChannel.type !== 'text' || window.DI.client.selectedChannel.permissionsFor(window.DI.client.user).has('EMBED_LINKS');
 
                 if (embedPerms) {
-                    window.DI.client.selectedChannel.send({ embed: embeds[0] });
+                    window.DI.client.selectedChannel.send({ content, embed: embeds[0] });
                 } else {
-                    window.DI.client.selectedChannel.send(embeds[0].description);
+                    window.DI.client.selectedChannel.send(`${embeds[0].title} | <${embeds[0].url}>\n\`\`\`\n${embeds[0].description}\`\`\``);
                 }
             } else {
-                log({ embeds });
+                log({ content, embeds });
             }
         });
     }

--- a/ExternalCommands/package.json
+++ b/ExternalCommands/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "image-size": "^0.6.1",
-    "superagent": "^3.5.2"
+    "superagent": "^3.5.2",
+    "google": "^2.1.0"
   }
 }


### PR DESCRIPTION
### Information

> Plugin Name: ExternalCommands
> DI Version Tested On:  3.2.0 and 3.2.1
> Original Author (mention if applicable):  @SnazzyPine25 

### Systems Tested On

Client:
 - [x] Stable
 - [ ] PTB
 - [X] Canary
 - [ ] Development

OS:
 - [X] Windows
 - [ ] Mac
 - [X] Linux (Gentoo)

### Plugin Changes
Adds a new command to the plugin (google.js).
Adds the required dependency for that command (`google`, `^2.1.0`) to ExternalCommands' package.json.

### Command description
The command allows you to search queries on Google and see the results for them.

Usage:
```
<prefix>google <query> [--send] [results: <number of results to be displayed>]
```
The `--send` flag will send the result to the channel the user is in, for everyone to see. If this flag isn't supplied, the result will be displayed in a client-side message.
The `results: <n>` parameter allows you to control how many results will be displayed. If the `--send` flag is supplied, this will be overridden to be `1`. The default value (in case the parameter isn't specified) is `3`.

### Additional Comments
Open to criticism. :smile: 