### PR TITLE
[data-reactroot] doesn't exist on react 16 anymore

### DIFF
--- a/CopyCode/index.js
+++ b/CopyCode/index.js
@@ -4,7 +4,7 @@ class CopyCode extends Plugin {
     constructor(...args) {
         super(...args);
         this.mo = new MutationObserver(this.check.bind(this));
-        this.mo.observe(document.querySelector("[data-reactroot]"), { childList: true, subtree: true });
+        this.mo.observe(document.querySelector("#app-mount>div"), { childList: true, subtree: true });
     }
 
     unload(){


### PR DESCRIPTION
### Information

> Plugin Name: CopyCode <br>
> DI Version Tested On: 3.2.2 dev <br>
> Original Author (mention if applicable):  <br>

### Systems Tested On

Client:
 - [x] Stable
 - [ ] PTB
 - [x] Canary
 - [ ] Development

OS:
 - [x] Windows
 - [ ] Mac
 - [ ] Linux (include distro)

### Plugin Changes

adjusted `[data-reactroot]` to `#app-mount>div`

### Additional Comments

pls approve @Snazzah senpai