### PR TITLE
Add ReactDevtools

### DIFF
--- a/ReactDevtools/README.md
+++ b/ReactDevtools/README.md
@@ -1,0 +1,7 @@
+# MediaSupport
+###### [Originally made by square](https://github.com/Inve1951/BetterDiscordStuff/blob/master/plugins/enableReactDevtools.plugin.js)
+
+You should place this file in the `Plugins` folder of the DiscordInjections project.
+
+Automatically loads the React Devtools for you.
+Requires [React-Devtools being installed in your chrome browser](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi).

--- a/ReactDevtools/README.md
+++ b/ReactDevtools/README.md
@@ -1,4 +1,4 @@
-# MediaSupport
+# ReactDevtools
 ###### [Originally made by square](https://github.com/Inve1951/BetterDiscordStuff/blob/master/plugins/enableReactDevtools.plugin.js)
 
 You should place this file in the `Plugins` folder of the DiscordInjections project.

--- a/ReactDevtools/index.js
+++ b/ReactDevtools/index.js
@@ -1,0 +1,43 @@
+const Plugin = module.parent.require('../Structures/Plugin');
+
+class ReactDevtools extends Plugin {
+    constructor(...args) {
+        super(...args);
+        this.listenerBind = this.listener.bind(this);
+        this.window = require("electron").remote.BrowserWindow.getAllWindows()[0];
+        try {
+            this.path = require("path").resolve(
+                process.env.LOCALAPPDATA, "Google/Chrome/User Data/Default/Extensions/fmkadmapgofadopljbjfkapdkoienihi/"
+            )
+            this.versions = require("fs").readdirSync( this.path );
+            this.path = require("path").resolve( this.path, this.versions[this.versions.length - 1] );
+            this.window.webContents.on("devtools-opened", this.listenerBind);
+        } catch (e) {
+            this.path = null;
+            if (e !== "ENOENT") throw e;
+            this.error("Couldn't find react devtools in chrome extensions! Install it here: https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi");
+            window.DI.PluginManager.unload("reactdevtools");
+        }
+    }
+
+    get configTemplate() {
+        return {
+            color: '5555ff'
+        };
+    }
+
+    unload() {
+        this.window.webContents.removeListener("devtools-opened", this.listenerBind);
+    }
+
+    listener(){
+        require("electron").remote.BrowserWindow.removeDevToolsExtension("React Developer Tools");
+        require("electron").webFrame.registerURLSchemeAsSecure("chrome-extension");
+        if( this.path != null && null != require("electron").remote.BrowserWindow.addDevToolsExtension( this.path ) )
+          this.log("Successfully installed react devtools.");
+        else
+          this.error("Couldn't find react devtools in chrome extensions!");
+    }
+}
+
+module.exports = ReactDevtools;

--- a/ReactDevtools/package.json
+++ b/ReactDevtools/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ReactDevtools",
+  "version": "0.1.0",
+  "description": "Automatically loads the React Devtools for you.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Snazzah, square",
+  "license": "MIT"
+}


### PR DESCRIPTION
### Information

> Plugin Name: ReactDevtools<br>
> DI Version Tested On:  3.2.2<br>
> Original Author (mention if applicable):  @Snazzah<br>

### Systems Tested On

Client:
 - [ ] Stable
 - [ ] PTB
 - [x] Canary
 - [x] Development

OS:
 - [x] Windows
 - [ ] Mac
 - [ ] Linux (include distro)

### Plugin Description

Automatically loads the React Devtools for you.