### PR TITLE
App selector fix

### DIFF
--- a/BetterFormattingRedux/index.js
+++ b/BetterFormattingRedux/index.js
@@ -30,7 +30,7 @@ class BFRedux extends Plugin {
 
         this.loadSettings();
         this.mo = new MutationObserver(this.init.bind(this));
-        this.mo.observe(document.querySelector("#app-mount>div"), { childList: true, subtree: true });
+        this.mo.observe(document.querySelector(".app-XZYfmp"), { childList: true, subtree: true });
         window.DI.DISettings.registerSettingsTab(this, 'Better Formatting Redux', BFSettings);
     }
 

--- a/CharacterCounter/index.js
+++ b/CharacterCounter/index.js
@@ -6,14 +6,14 @@ class CharacterCounter extends Plugin {
         super(...args);
         this.didInit = false;
         this.mo = new MutationObserver(this.init.bind(this));
-        this.mo.observe(document.querySelector("#app-mount>div"), { childList: true, subtree: true });
+        this.mo.observe(document.querySelector(".app-XZYfmp"), { childList: true, subtree: true });
     }
 
     init() {
         if(document.querySelector("#charcounter")) return;
         let ta = document.querySelector(".channel-text-area-default");
         if(!ta) return;
-        this.log("Initializing Counter...");
+        //this.log("Initializing Counter...");
         let eventhandler = e => {
             setTimeout(() => {
                 let length = e.target.value.length;

--- a/CopyCode/index.js
+++ b/CopyCode/index.js
@@ -4,7 +4,7 @@ class CopyCode extends Plugin {
     constructor(...args) {
         super(...args);
         this.mo = new MutationObserver(this.check.bind(this));
-        this.mo.observe(document.querySelector("#app-mount>div"), { childList: true, subtree: true });
+        this.mo.observe(document.querySelector(".app-XZYfmp"), { childList: true, subtree: true });
     }
 
     unload(){

--- a/DiscordCardsDashboard/index.js
+++ b/DiscordCardsDashboard/index.js
@@ -13,7 +13,7 @@ class DiscordCardsDashboard extends Plugin {
     constructor(...args) {
         super(...args);
         this.mo = new MutationObserver(this.check.bind(this));
-        this.mo.observe(document.querySelector("#app-mount>div"), { childList: true, subtree: true });
+        this.mo.observe(document.querySelector(".app-XZYfmp"), { childList: true, subtree: true });
         this.sbind = this.switched.bind(this);
         window.DI.client.on('selectedUpdate', this.sbind);
         window.DI.client.once('ready', ()=>{this.switched({}, {channel:window.DI.client.selectedChannel})});

--- a/ForceClose/index.js
+++ b/ForceClose/index.js
@@ -3,13 +3,13 @@ const Plugin = module.parent.require('../Structures/Plugin');
 class ForceClose extends Plugin {
     constructor(...args) {
         super(...args);
-        document.querySelector(".win-close").onclick = function(){
+        document.querySelector(".winButtonClose-2rIvsa").onclick = function(){
             require("electron").remote.require("electron").app.quit();
         };
     }
 
     unload() {
-        document.querySelector(".win-close").onclick = null;
+        document.querySelector(".winButtonClose-2rIvsa").onclick = null;
     }
 }
 

--- a/LineStickers/Modules/Observer.js
+++ b/LineStickers/Modules/Observer.js
@@ -4,7 +4,7 @@ class Observer {
     constructor(plugin) {
         this.plugin = plugin;
         this.mo = new MutationObserver(this.observer.bind(this));
-        this.mo.observe(document.querySelector("#app-mount>div"), { childList: true, subtree: true });
+        this.mo.observe(document.querySelector(".app-XZYfmp"), { childList: true, subtree: true });
     }
     observer(recs){
         let self = this;

--- a/QuickSave/index.js
+++ b/QuickSave/index.js
@@ -9,7 +9,7 @@ class QuickSave extends Plugin {
     constructor(...args) {
         super(...args);
         this.mo = new MutationObserver(this.observer.bind(this));
-        this.mo.observe(document.querySelector("#app-mount>div"), { childList: true, subtree: true });
+        this.mo.observe(document.querySelector(".app-XZYfmp"), { childList: true, subtree: true });
         window.DI.DISettings.registerSettingsTab(this, 'QuickSave', QSSettings);
     }
 
@@ -28,8 +28,7 @@ class QuickSave extends Plugin {
                 let filetype =  '.'+url.split('.').slice(-1)[0].split('?')[0];
 
                 let loops = 50;
-                const dest = _path.join(dir, filename, filetype);
-                while(plugin.accessSync(dest) && loops--)
+                while(plugin.accessSync(dir+(dir.endsWith("\\")?"":"\\")+filename+filetype) && loops--)
                     filename = plugin.randomFilename64(parseInt(settings.fnLength));
 
                 if(loops == -1){
@@ -50,8 +49,7 @@ class QuickSave extends Plugin {
 
                 let num = 2;
                 let loops = 2048;
-                const dest = _path.join(dir, filename);
-                while(plugin.accessSync(dest) && loops--) {
+                while( plugin.accessSync(dir+(dir.endsWith("\\")?"":"\\")+filename) && loops-- ){
                     filename = filename_original + ` (${num})` + filetype_original;
                     num++;
                 }
@@ -283,7 +281,7 @@ class QuickSave extends Plugin {
             return;
         }
 
-        const dest = _path.join(dir, filename);
+        var dest = dir+(dir.endsWith("\\")?"":"\\")+filename;
         self.log("Quicksaving", url, '-->', dest);
 
         var file = fs.createWriteStream(dest);

--- a/ResizeX/index.js
+++ b/ResizeX/index.js
@@ -13,7 +13,7 @@ class ResizeX extends Plugin {
         super(...args);
         let plugin = this;
         this.mo = new MutationObserver(this.init.bind(this));
-        this.mo.observe(document.querySelector("#app-mount>div"), { childList: true, subtree: true });
+        this.mo.observe(document.querySelector(".app-XZYfmp"), { childList: true, subtree: true });
         $(document).on("mousemove.resizex", function(e) {
             if (resizexHandle) {
                 $(resizexHandle).siblings().width(resizexWidth + (e.pageX - resizexX + e.pageY - resizexY) / 2);

--- a/TelegramStickers/Modules/Observer.js
+++ b/TelegramStickers/Modules/Observer.js
@@ -4,7 +4,7 @@ class Observer {
     constructor(plugin) {
         this.plugin = plugin;
         this.mo = new MutationObserver(this.observer.bind(this));
-        this.mo.observe(document.querySelector("#app-mount>div"), { childList: true, subtree: true });
+        this.mo.observe(document.querySelector(".app-XZYfmp"), { childList: true, subtree: true });
     }
     observer(recs){
         let self = this;

--- a/betterNSFW/index.js
+++ b/betterNSFW/index.js
@@ -4,7 +4,7 @@ class BetterNSFW extends Plugin {
     constructor(...args) {
         super(...args);
         this.mo = new MutationObserver(this.check.bind(this));
-        this.mo.observe(document.querySelector("#app-mount>div"), { childList: true, subtree: true });
+        this.mo.observe(document.querySelector(".app-XZYfmp"), { childList: true, subtree: true });
     }
 
     get configTemplate() {
@@ -43,7 +43,7 @@ class BetterNSFW extends Plugin {
             if (channelname === undefined) return
             channelname = channelname.childNodes[0];
             if(!channel.classList.contains("nsfw-filtered") && ((svg.childNodes.length > 1 && svg.childNodes[1].getAttribute("d").startsWith("M9.75,8")) || nsfwRegex.test(channelname.data)) &&
-				channel.querySelector('.nsfw-channel-tag') === null){
+                channel.querySelector('.nsfw-channel-tag') === null){
                 channel.classList.add("nsfw-filtered");
                 channelname.parentNode.outerHTML += `<span class="nsfw-channel-tag">18+</span>`;
                 //channelname.data = channelname.data.replace(/^nsfw-/, "");

--- a/greentext/index.js
+++ b/greentext/index.js
@@ -7,7 +7,7 @@ class greentext extends Plugin {
         super(...args);
         this.didInit = false;
         this.mo = new MutationObserver(this.init.bind(this));
-        this.mo.observe(document.querySelector("#app-mount>div"), { childList: true, subtree: true });
+        this.mo.observe(document.querySelector(".app-XZYfmp"), { childList: true, subtree: true });
         window.DI.DISettings.registerSettingsTab(this, 'greentext', greentextSettings);
         window.DI.client.on('selectedUpdate', this.recolor.bind(this));
         this.recolor();
@@ -27,12 +27,11 @@ class greentext extends Plugin {
         if(!this.settings.orangetext) document.querySelectorAll(".markup>.orangetext").forEach(e => e.outerHTML = e.innerHTML);
         m.forEach(mr => {
             if(mr.addedNodes) mr.addedNodes.forEach(e => {
-                if(e.classList && e.classList.contains("message") && !e.classList.contains("message-sending")) this.process(e.childNodes[0].childNodes[0].childNodes[e.childNodes[0].childNodes[0].childNodes.length === 2 ? 1 : 2]);
+                if(e.classList && e.classList.contains("message") && !e.classList.contains("message-sending")) this.process(e.childNodes[0].childNodes[0].childNodes[2]);
                 if(e.classList && e.classList.contains("message-group")){
                     if(!e.childNodes[1].childNodes[0].classList.contains("message-sending")){
                         e.childNodes[1].childNodes.forEach(me => {
-                            var messageNode = me.childNodes[0].childNodes[me.classList.contains("first") ? 1 : 0];
-                            this.process(messageNode.childNodes[messageNode.childNodes.length === 2 ? 1 : 2]);
+                            this.process(me.childNodes[0].childNodes[me.classList.contains("first") ? 1 : 0].childNodes[2]);
                         });
                     }
                 }


### PR DESCRIPTION
### Information

> Plugin Name: BetterNSFW, DiscordCardsDashboard, QuickSave, LineStickers, TelegramStickers, ForceClose, ResizeX, greentext, CharacterCounter, CopyCode<br>
> DI Version Tested On:  3.2.2<br>
> Original Author (mention if applicable):  @Snazzah<br>

### Systems Tested On

Client:
 - [ ] Stable
 - [ ] PTB
 - [x] Canary
 - [x] Development

OS:
 - [x] Windows
 - [ ] Mac
 - [ ] Linux (include distro)

### Plugin Changes

Changes all app selectors to `.app-XZYfmp`. Also fixes another bug in ForceClose.
