### PR TITLE
Fix SilentTyping "timestamp bug"

### DIFF
--- a/SilentTyping/index.js
+++ b/SilentTyping/index.js
@@ -5,12 +5,14 @@ class SilentTyping extends Plugin {
     constructor(...args) {
         super(...args);
 
-        const module = WebpackModules.findByUniqueProperties(["sendTyping"]);
-        if (!module) {
-            this.log("unable to monkey patch sendTyping method");
-            return;
-        }
-        this._cancel = monkeyPatch(module, "sendTyping", {instead: ()=>{}});
+        window.setTimeout(()=>{
+            const module = WebpackModules.findByUniqueProperties(["sendTyping"]);
+            if (!module) {
+                this.log("unable to monkey patch sendTyping method");
+                return;
+            }
+            this._cancel = monkeyPatch(module, "sendTyping", {instead: ()=>{}});
+        }, 1000);
     }
 
     unload() {

--- a/SilentTyping/internals.js
+++ b/SilentTyping/internals.js
@@ -1,26 +1,26 @@
 /**
- * Function with no arguments and no return value that may be called to reverse changes that is done by {@link monkeyPatch} method, restoring (unpatching) original method.
+ * Function with no arguments and no return value that may be called to revert changes made by {@link monkeyPatch} method, restoring (unpatching) original method.
  * @callback cancelPatch
  */
 
 /**
- * This is a shortcut for calling original method using this and arguments from data object. This is a function without input arguments. This function is defined as `() => data.returnValue = data.originalMethod.apply(data.thisObject, data.methodArguments)`
+ * This is a shortcut for calling original method using `this` and `arguments` from original call. This function accepts no arguments. This function is defined as `() => data.returnValue = data.originalMethod.apply(data.thisObject, data.methodArguments)`
  * @callback originalMethodCall
  * @return {*} The same value, which is returned from original method, also this value would be written into `data.returnValue`
  */
 
 /**
- * A callback that modifies method logic. Callback is called on each call of original method and have all data about original call. Any of the data can be modified if you need, but do it wisely.
+ * A callback that modifies method logic. This callback is called on each call of the original method and is provided all data about original call. Any of the data can be modified if necessary, but do so wisely.
  * @callback doPatchCallback
- * @param {PatchData} data Data object with all information about current that you may need in your patching callback.callback.
- * @return {*} Makes sense only when used as `instead` parameter in {@link monkeyPatch}. If returned something other then undefined - it replaces value in `returnValue` param. If used as `before` or `after` parameters - return value if ignored.
+ * @param {PatchData} data Data object with information about current call and original method that you may need in your patching callback.
+ * @return {*} Makes sense only when used as `instead` parameter in {@link monkeyPatch}. If something other than `undefined` is returned, the returned value replaces the value of `data.returnValue`. If used as `before` or `after` parameters, return value is ignored.
  */
 
 /**
- * This is function for monkey-patching any object method. Can make patch before, after or instead of target method.
- * Be careful when monkey-patching. Think not only about original functionality of target method and you changes, but also about develovers of other plugins, who may also patch this method before or after you. Try to change target method behaviour little as you can, and try to never change method signatures.
- * By default this function makes log messages about each patching and unpatching, so you and other developers can see what methods a patched. This messages may be suppressed.
- * Display name of patched method is changed, so you can see if function is patched and how many times while debuging or in the stack trace. Also patched function have property `__monkeyPatched` is set to true, in case you want to check something programmatically.
+ * This function monkey-patches a method on an object. The patching callback may be run before, after or instead of target method.
+ * Be careful when monkey-patching. Think not only about original functionality of target method and your changes, but also about developers of other plugins, who may also patch this method before or after you. Try to change target method behaviour as little as possible, and avoid changing method signatures.
+ * By default, this function logs to the console whenever a method is patched or unpatched in order to aid debugging by you and other developers, but these messages may be suppressed with the `silent` option.
+ * Display name of patched method is changed, so you can see if a function has been patched (and how many times) while debugging or in the stack trace. Also, patched methods have property `__monkeyPatched` set to `true`, in case you want to check something programmatically.
  *
  * @author samogot
  * @param {object} what Object to be patched. You can can also pass class prototypes to patch all class instances. If you are patching prototype of react component you may also need {@link Renderer.rebindMethods}.
@@ -29,9 +29,9 @@
  * @param {doPatchCallback} options.before Callback that will be called before original target method call. You can modify arguments here, so it will be passed to original method. Can be combined with `after`.
  * @param {doPatchCallback} options.after Callback that will be called after original target method call. You can modify return value here, so it will be passed to external code which calls target method. Can be combined with `before`.
  * @param {doPatchCallback} options.instead Callback that will be called instead of original target method call. You can get access to original method using `originalMethod` parameter if you want to call it, but you do not have to. Can't be combined with `before` and `after`.
- * @param {boolean} [options.once=false] Set to true if you want automatically unpatch method after first call.
- * @param {boolean} [options.silent=false] Set to true if you want to suppress log messages about patching and unpatching. Useful to avoid clogging the console in case of frequent conditional patching/unpatching, for example from another monkeyPatch callback.
- * @param {boolean} [options.displayName] You can provide meaningful name of class/object provided in `what` param for logging purposes. By default there will be a try to determine name automatically.
+ * @param {boolean} [options.once=false] Set to `true` if you want to automatically unpatch method after first call.
+ * @param {boolean} [options.silent=false] Set to `true` if you want to suppress log messages about patching and unpatching. Useful to avoid clogging the console in case of frequent conditional patching/unpatching, for example from another monkeyPatch callback.
+ * @param {string} [options.displayName] You can provide meaningful name for class/object provided in `what` param for logging purposes. By default, this function will try to determine name automatically.
  * @return {cancelPatch} Function with no arguments and no return value that should be called to cancel (unpatch) this patch. You should save and run it when your plugin is stopped.
  */
 const monkeyPatch = (what, methodName, options) => {
@@ -50,9 +50,9 @@ const monkeyPatch = (what, methodName, options) => {
          * @property {object} thisObject Original `this` value in current call of patched method.
          * @property {Arguments} methodArguments Original `arguments` object in current call of patched method. Please, never change function signatures, as it may cause a lot of problems in future.
          * @property {cancelPatch} cancelPatch Function with no arguments and no return value that may be called to reverse patching of current method. Calling this function prevents running of this callback on further original method calls.
-         * @property {function} originalMethod Reference to the original method that is patched. You can use in if you need some special usage. You should explicitly provide this value and method arguments when you call this function.
-         * @property {originalMethodCall} callOriginalMethod This is a shortcut for calling original method using this and arguments from data object.
-         * @property {*} returnValue This is a value returned from original function call. This property is avilable only in `after` callback, or in `instead` callback after calling `callOriginalMethod` function
+         * @property {function} originalMethod Reference to the original method that is patched. You can use it if you need some special usage. You should explicitly provide a value for `this` and any method arguments when you call this function.
+         * @property {originalMethodCall} callOriginalMethod This is a shortcut for calling original method using `this` and `arguments` from original call.
+         * @property {*} returnValue This is a value returned from original function call. This property is available only in `after` callback or in `instead` callback after calling `callOriginalMethod` function.
          */
         const data = {
             thisObject: this,
@@ -94,31 +94,38 @@ const WebpackModules = (() => {
      * Predicate for searching module
      * @callback modulePredicate
      * @param {*} module Module to test
-     * @return {boolean} Thue if it is module that you need
+     * @return {boolean} Returns `true` if `module` matches predicate.
      */
 
     /**
-     * Look through all modules of internal Discord's Webpack and return first one that match filter predicate.
-     * At first this function will look thruogh alreary loaded modules cache. If no one of loaded modules is matched - then this function tries to load all modules and match for them. Loading any module may have unexpected side effects, like changing current locale of moment.js, so in that case there will be a warning the console. If no module matches - function will return null. You sould always take such predicate to match something, gut your code should be ready to recieve null in case if Discord update something in codebase.
-     * If module is ES6 module and hafe default property - only default would be considered, otherwise - full module object.
+     * Look through all modules of internal Discord's Webpack and return first one that matches filter predicate.
+     * At first this function will look through already loaded modules cache. If no loaded modules match, then this function tries to load all modules and match for them. Loading any module may have unexpected side effects, like changing current locale of moment.js, so in that case there will be a warning the console. If no module matches, this function returns `null`. You should always try to provide a predicate that will match something, but your code should be ready to receive `null` in case of changes in Discord's codebase.
+     * If module is ES6 module and has default property, consider default first; otherwise, consider the full module object.
      * @param {modulePredicate} filter Predicate to match module
-     * @return {*} First module that matched by filter or null if none is matched.
+     * @param {object} [options] Options object.
+     * @param {boolean} [options.cacheOnly=false] Set to `true` if you want to search only the cache for modules.
+     * @return {*} First module that matches `filter` or `null` if none match.
      */
-    const find = (filter) => {
+    const find = (filter, options = {}) => {
+        const {cacheOnly = true} = options;
         for (let i in req.c) {
             if (req.c.hasOwnProperty(i)) {
                 let m = req.c[i].exports;
-                if (m && m.__esModule && m.default)
-                    m = m.default;
+                if (m && m.__esModule && m.default && filter(m.default))
+                    return m.default;
                 if (m && filter(m))
                     return m;
             }
         }
+        if (cacheOnly) {
+            console.warn('Cannot find loaded module in cache');
+            return null;
+        }
         console.warn('Cannot find loaded module in cache. Loading all modules may have unexpected side effects');
         for (let i = 0; i < req.m.length; ++i) {
             let m = req(i);
-            if (m && m.__esModule && m.default)
-                m = m.default;
+            if (m && m.__esModule && m.default && filter(m.default))
+                return m.default;
             if (m && filter(m))
                 return m;
         }
@@ -127,21 +134,23 @@ const WebpackModules = (() => {
     };
 
     /**
-     * Look through all modules of internal Discord's Webpack and return first object that has all of following properties. You should be ready that in any moment, after Discord update, this function may start returning null (if no such object exists any more) or even some different object with the same properties. So you should provide all property names that you use, and often even some extra properties to make sure you'll get exactly what you want.
+     * Look through all modules of internal Discord's Webpack and return first object that has all of following properties. You should be ready that in any moment, after Discord update, this function may start returning `null` (if no such object exists anymore) or even some different object with the same properties. So you should provide all property names that you use, and often even some extra properties to make sure you'll get exactly what you want.
      * @see Read {@link find} documentation for more details how search works
      * @param {string[]} propNames Array of property names to look for
-     * @return {object} First module that matched by propNames or null if none is matched.
+     * @param {object} [options] Options object to pass to {@link find}.
+     * @return {object} First module that matches `propNames` or `null` if none match.
      */
-    const findByUniqueProperties = (propNames) => find(module => propNames.every(prop => module[prop] !== undefined));
+    const findByUniqueProperties = (propNames, options) => find(module => propNames.every(prop => module[prop] !== undefined), options);
 
     /**
-     * Look through all modules of internal Discord's Webpack and return first object that has displayName property with following value. This is useful for searching React components by name. Take into account that not all components are exported as modules. Also there might be several components with same names
+     * Look through all modules of internal Discord's Webpack and return first object that has `displayName` property with following value. This is useful for searching for React components by name. Take into account that not all components are exported as modules. Also, there might be several components with the same name.
      * @see Use {@link ReactComponents} as another way to get react components
      * @see Read {@link find} documentation for more details how search works
      * @param {string} displayName Display name property value to look for
-     * @return {object} First module that matched by displayName or null if none is matched.
+     * @param {object} [options] Options object to pass to {@link find}.
+     * @return {object} First module that matches `displayName` or `null` if none match.
      */
-    const findByDisplayName = (displayName) => find(module => module.displayName === displayName);
+    const findByDisplayName = (displayName, options) => find(module => module.displayName === displayName, options);
 
     return {find, findByUniqueProperties, findByDisplayName};
 

--- a/SilentTyping/package.json
+++ b/SilentTyping/package.json
@@ -1,6 +1,6 @@
 {
   "name": "SilentTyping",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Don't send typing notifications",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Information

> Plugin Name:  SilentTyping<br>
> DI Version Tested On:  3.3.2<br>
> Original Author:  noodlebox<br>

### Systems Tested On

Client:
 - [ ] Stable
 - [ ] PTB
 - [x] Canary
 - [ ] Development

OS:
 - [ ] Windows
 - [ ] Mac
 - [X] Linux (Ubuntu)

### Plugin Changes

Updates to a newer version of the DiscordInternals code (internals.js) which should avoid the Chinese timestamp bug. Also adds a short delay to the setup code as a workaround to deal with the lazy loading of Discord's webpack modules.