### PR TITLE
Add DiscordTrackingBlocker

### DIFF
--- a/DiscordTrackingBlocker/index.js
+++ b/DiscordTrackingBlocker/index.js
@@ -1,0 +1,15 @@
+const Plugin = module.parent.require('../Structures/Plugin');
+class DiscordTrackingBlocker extends Plugin {
+    load() {
+        XMLHttpRequest.prototype._oldOpen = XMLHttpRequest.prototype.open;
+        XMLHttpRequest.prototype.open = function (u, r) {
+            if ((/\/track$/i).test(r)) {
+                throw new Error('Tracking request blocked!');
+            }
+            XMLHttpRequest.prototype._oldOpen.apply(this, arguments);
+        };
+    }
+    
+    get configTemplate() { return { color: '00ff85', }; }
+}
+module.exports = DiscordTrackingBlocker;

--- a/DiscordTrackingBlocker/package.json
+++ b/DiscordTrackingBlocker/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "DiscordTrackingBlocker",
+  "version": "1.0.0",
+  "description": "Blocks connections to the /track endpoint within the client",
+  "main": "index.js",
+  "scripts": {},
+  "author": "Pointy",
+  "license": "ISC"
+}

--- a/DiscordTrackingBlocker/readme.md
+++ b/DiscordTrackingBlocker/readme.md
@@ -1,0 +1,3 @@
+# DiscordTrackingBlocker
+
+`DiscordTrackingBlocker` aims to help you block tracking requests so Discord can't figure out what you're up to or something. Plugin autoruns on load, and requires an unload and client restart to be removed.


### PR DESCRIPTION
### Information

> Plugin Name: DiscordTrackingBlocker
> DI Version Tested On: 3.3.2
> Original Author (mention if applicable): [Pointy](https://github.com/pointydev)

### Systems Tested On

Client:
 - [x] Stable
 - [ ] PTB
 - [x] Canary
 - [ ] Development

OS:
 - [x] Windows
 - [x] Mac
 - [ ] Linux (include distro)

### Plugin Description

`DiscordTrackingBlocker` aims to help you block tracking requests so Discord can't figure out what you're up to or something. Plugin autoruns on load, and requires an unload and client restart to be removed.